### PR TITLE
feat: 支持多候选模型配置及自动回退机制

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ UIAUTO_REQUEST_TIMEOUT=60                # 或使用 REQUEST_TIMEOUT（旧版兼
 # 代理配置（可选）
 # UIAUTO_MODEL_PROXY=http://127.0.0.1:7890  # 或使用 MODEL_PROXY（旧版兼容）
 
+# ========== 任务输出配置（可选）==========
+# 报告输出目录。设置后所有报告文件直接写入此目录（跳过 uiautoagent_reports/task_xxx/ 子目录）
+# 不设置则输出到 uiautoagent_reports/task_YYYYMMDD_HHMMSS/
+# UIAUTO_REPORT_DIR=/absolute/path/to/report
+
 # ========== OpenRouter 追踪（可选）==========
 # OPENROUTER_SITE_URL=https://yoursite.com
 # OPENROUTER_SITE_NAME=YourAppName

--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,7 @@ task_*.yaml*
 
 # Task execution directories
 uiautoagent_tasks/
+uiautoagent_reports/
 devimages/
 tasks/
 *.swp

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ UIAUTO_MODEL_PROXY=http://127.0.0.1:7890
 # 请求超时时间（秒）
 UIAUTO_REQUEST_TIMEOUT=60
 
+# 报告输出目录（可选）
+UIAUTO_REPORT_DIR=/path/to/reports   # 设置后直接写入此目录，不设则输出到 uiautoagent_reports/task_xxx/
+
 # OpenRouter 请求追踪（可选）
 OPENROUTER_SITE_URL=https://yoursite.com
 OPENROUTER_SITE_NAME=YourAppName
@@ -52,19 +55,21 @@ SESSION_ID=my-session-123   # 默认自动生成 UUID
 >
 > 模型环境变量支持使用逗号分隔多个候选模型，顺序就是回退顺序；当当前模型调用失败时，会自动尝试下一个候选模型。
 
-推荐的模型
+### 全部环境变量
 
-- doubao-seed-2.0-pro
-- glm-5v-turbo
-
-其他的欢迎补充
-
-### 场景说明
-
-| 场景 | 环境变量 | 说明 | 模型要求 |
-|------|----------|------|----------|
-| `VISION` | `UIAUTO_MODEL_VISION` | 视觉模型候选列表（规划+检测，逗号分隔） | 需要视觉能力 |
-| `TEXT` | `UIAUTO_MODEL_TEXT` | 文本模型候选列表（总结、澄清、搜索，逗号分隔） | 纯文本，无视觉要求 |
+| 变量名 | 旧版兼容 | 默认值 | 说明 |
+|--------|----------|--------|------|
+| `UIAUTO_BASE_URL` | `BASE_URL` | `https://api.openai.com/v1` | OpenAI 兼容 API 地址 |
+| `UIAUTO_API_KEY` | `API_KEY` | — | API 密钥 |
+| `UIAUTO_MODEL_NAME` | `MODEL_NAME` | `doubao-seed-2.0-pro` | 默认模型候选（逗号分隔，按顺序回退） |
+| `UIAUTO_MODEL_VISION` | `MODEL_VISION` | 同 `MODEL_NAME` | 视觉模型候选（规划+检测，需要视觉能力） |
+| `UIAUTO_MODEL_TEXT` | `MODEL_TEXT` | 同 `MODEL_NAME` | 文本模型候选（总结、澄清、搜索） |
+| `UIAUTO_MODEL_PROXY` | `MODEL_PROXY` | — | HTTP 代理（如 `http://127.0.0.1:7890`） |
+| `UIAUTO_REQUEST_TIMEOUT` | `REQUEST_TIMEOUT` | `60` | 请求超时（秒） |
+| `UIAUTO_REPORT_DIR` | — | — | 报告输出目录。设置后跳过 `task_xxx/` 子目录，直接写入此路径 |
+| `OPENROUTER_SITE_URL` | — | — | OpenRouter 站点 URL（请求追踪） |
+| `OPENROUTER_SITE_NAME` | — | — | OpenRouter 站点名称（请求追踪） |
+| `SESSION_ID` | — | 自动生成 UUID | 会话 ID，用于请求追踪 |
 
 ## 快速开始
 
@@ -116,7 +121,7 @@ uv run uiautoagent -m manual  # 手动控制
 
 ## 任务报告
 
-每次任务执行完成后，会在 `uiautoagent_tasks/task_xxx/` 目录下生成：
+每次任务执行完成后，会在 `uiautoagent_reports/task_xxx/` 目录下生成：
 
 | 文件 | 说明 |
 |------|------|

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ AI 驱动的 UI 自动化框架，支持视觉定位和自主任务执行。
 - 🤖 自主规划执行任务
 - 🧠 任务记忆学习
 - 📱 Android / iOS 设备支持
-- 🔧 灵活的模型配置（支持不同场景使用不同模型）
+- 🔧 灵活的模型配置（支持不同场景使用不同模型，并可按顺序回退）
 - 📊 可视化 HTML 报告（标注截图、token 消耗、耗时）
 - 📸 AI 图片内容提取（结构化 JSON 输出）
-- 🔍 启动时自动检查模型可用性
+- 🔍 启动时自动检查模型候选可用性
 - 🖼️ 操作前后截图对比（AI 可根据界面变化判断操作是否生效）
 
 ## 安装
@@ -30,11 +30,11 @@ cp .env.example .env
 # 基础配置（推荐使用 UIAUTO_ 前缀，旧版变量名仍然支持）
 UIAUTO_BASE_URL=--openai-compatable--
 UIAUTO_API_KEY=sk-xxx
-UIAUTO_MODEL_NAME=--suport-vision-model--
+UIAUTO_MODEL_NAME=doubao-seed-2.0-pro,glm-4.6v  # 默认候选模型，按顺序回退
 
 # 可选：为不同场景配置不同的模型
-UIAUTO_MODEL_VISION=         # 视觉模型（规划+检测，需要视觉能力）
-UIAUTO_MODEL_TEXT=           # 文本处理模型（总结、澄清等）
+UIAUTO_MODEL_VISION=doubao-seed-2.0-pro  # 视觉模型候选（规划+检测）
+UIAUTO_MODEL_TEXT=gpt-4o-mini,deepseek-chat          # 文本模型候选（总结、澄清等）
 
 # 代理配置（可选）
 UIAUTO_MODEL_PROXY=http://127.0.0.1:7890
@@ -49,6 +49,8 @@ SESSION_ID=my-session-123   # 默认自动生成 UUID
 ```
 
 > **注意**：环境变量已升级为 `UIAUTO_` 前缀以避免命名冲突。旧版变量名（如 `BASE_URL`、`API_KEY` 等）仍然支持，但推荐使用新的前缀版本。
+>
+> 模型环境变量支持使用逗号分隔多个候选模型，顺序就是回退顺序；当当前模型调用失败时，会自动尝试下一个候选模型。
 
 推荐的模型
 
@@ -61,8 +63,8 @@ SESSION_ID=my-session-123   # 默认自动生成 UUID
 
 | 场景 | 环境变量 | 说明 | 模型要求 |
 |------|----------|------|----------|
-| `VISION` | `UIAUTO_MODEL_VISION` | 视觉模型（规划+检测） | 需要视觉能力 |
-| `TEXT` | `UIAUTO_MODEL_TEXT` | 文本处理（总结、澄清、搜索） | 纯文本，无视觉要求 |
+| `VISION` | `UIAUTO_MODEL_VISION` | 视觉模型候选列表（规划+检测，逗号分隔） | 需要视觉能力 |
+| `TEXT` | `UIAUTO_MODEL_TEXT` | 文本模型候选列表（总结、澄清、搜索，逗号分隔） | 纯文本，无视觉要求 |
 
 ## 快速开始
 
@@ -102,12 +104,14 @@ uv run uiautoagent -m manual  # 手动控制
 - 应用 UI 比较复杂，需要提供元素位置提示
 - 任务需要特定领域的知识（如某个 App 的特殊操作方式）
 
-启动时会自动检查所有配置模型的可用性：
+启动时会自动检查所有配置模型候选的可用性，每个场景至少要有一个候选模型可用：
 
 ```
-🔍 检查模型可用性（共 2 个）...
-  ✅ 'gpt-5.4' [default, vision]
-  ✅ 'gpt-4o-mini' [text]
+🔍 检查模型可用性（共 4 个候选）...
+  ✅ 'glm-4.6v' [default #1]
+  ❌ 'doubao-seed-2.0-pro' [vision #1]
+  ✅ 'glm-5v-turbo' [vision #2]
+  ✅ 'gpt-4o-mini' [text #1]
 ```
 
 ## 任务报告
@@ -229,6 +233,8 @@ response = chat_completion(
     max_tokens=500,
 )
 content = response.choices[0].message.content
+
+# 未显式传 model 时，会按该场景配置的候选模型顺序自动回退
 
 # 视觉场景（需要图片）
 vision_response = chat_completion(

--- a/src/uiautoagent/agent/device_agent.py
+++ b/src/uiautoagent/agent/device_agent.py
@@ -577,8 +577,8 @@ class DeviceAgent:
         if self.config.report_dir:
             return
 
-        tasks_dir = Path("uiautoagent_reports")
-        latest_link = tasks_dir / "latest"
+        reports_root = Path("uiautoagent_reports")
+        latest_link = reports_root / "latest"
 
         try:
             # 如果已存在 latest 软链接，先删除

--- a/src/uiautoagent/agent/device_agent.py
+++ b/src/uiautoagent/agent/device_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from datetime import datetime
 from pathlib import Path
@@ -10,7 +11,7 @@ from typing import Any
 
 import dictlog
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from uiautoagent.controller.base import DeviceController, SwipeDirection
 from uiautoagent.types import TokenUsage
@@ -142,7 +143,9 @@ class AgentConfig(BaseModel):
     """Agent配置"""
 
     max_steps: int = 20  # 最大执行步数
-    tasks_dir: str = "uiautoagent_tasks"  # 任务目录父目录
+    report_dir: str | None = Field(
+        default_factory=lambda: os.getenv("UIAUTO_REPORT_DIR")
+    )  # 报告输出目录，可通过 UIAUTO_REPORT_DIR 环境变量覆盖
     save_screenshots: bool = True
     verbose: bool = True
 
@@ -174,13 +177,18 @@ class DeviceAgent:
         self._last_screenshot_time: float = 0  # 上一步操作后的截图时间戳
         self._screenshot_ttl: float = 1  # 截图有效期（秒）
 
-        # 创建带时间戳的唯一任务目录
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.task_dir = Path(self.config.tasks_dir) / f"task_{timestamp}"
-        self.task_dir.mkdir(parents=True, exist_ok=True)
+        # 创建任务输出目录
+        if self.config.report_dir:
+            self.report_dir = Path(self.config.report_dir)
+            if self.report_dir.exists():
+                self._log(f"⚠️  报告目录已存在，输出文件将被覆盖: {self.report_dir}")
+        else:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            self.report_dir = Path("uiautoagent_reports") / f"task_{timestamp}"
+        self.report_dir.mkdir(parents=True, exist_ok=True)
 
         # 截图子目录
-        self.screenshot_dir = self.task_dir / "screenshots"
+        self.screenshot_dir = self.report_dir / "screenshots"
         self.screenshot_dir.mkdir(exist_ok=True)
 
     def _take_screenshot(self) -> Path:
@@ -479,7 +487,7 @@ class DeviceAgent:
 
     def _append_step_log(self, step: TaskStep) -> None:
         """将单步执行记录实时追加到 log.txt"""
-        log_path = self.task_dir / "log.txt"
+        log_path = self.report_dir / "log.txt"
 
         # 格式化步骤信息
         status = "✅ 成功" if step.success else "❌ 失败"
@@ -517,7 +525,7 @@ class DeviceAgent:
     def save_history(self, path: str | Path | None = None):
         """保存任务历史到JSON文件"""
         if path is None:
-            path = self.task_dir / "history.json"
+            path = self.report_dir / "history.json"
 
         # 从全局TokenTracker获取统计
         from uiautoagent.ai import TokenTracker
@@ -561,14 +569,15 @@ class DeviceAgent:
         """生成HTML可视化报告"""
         from uiautoagent.agent.report import generate_html_report
 
-        report_path = generate_html_report(self.history, self.task_dir, self.task)
+        report_path = generate_html_report(self.history, self.report_dir, self.task)
         self._log(f"📊 HTML报告已保存至: {report_path}")
 
     def _update_latest_symlink(self):
         """创建/更新 latest 软链接指向当前任务目录"""
-        import os
+        if self.config.report_dir:
+            return
 
-        tasks_dir = Path(self.config.tasks_dir)
+        tasks_dir = Path("uiautoagent_reports")
         latest_link = tasks_dir / "latest"
 
         try:
@@ -578,7 +587,7 @@ class DeviceAgent:
 
             # 创建相对路径的软链接（更便携）
             # 获取任务目录名称（如 "task_20240121_123456"）
-            task_dir_name = self.task_dir.name
+            task_dir_name = self.report_dir.name
             os.symlink(task_dir_name, latest_link)
 
             self._log(f"🔗 软链接已更新: {latest_link} -> {task_dir_name}")
@@ -588,7 +597,7 @@ class DeviceAgent:
 
     def _save_text_summary(self):
         """保存可读的文本摘要"""
-        summary_path = self.task_dir / "summary.txt"
+        summary_path = self.report_dir / "summary.txt"
 
         # 从全局TokenTracker获取统计
         from uiautoagent.ai import TokenTracker

--- a/src/uiautoagent/agent/executor.py
+++ b/src/uiautoagent/agent/executor.py
@@ -478,7 +478,7 @@ def run_ai_task(
         model=info["model"],
         width=info["width"],
         height=info["height"],
-        task_dir=agent.task_dir,
+        report_dir=agent.report_dir,
     )
 
     log.info("任务", task=task, has_context=context is not None)

--- a/src/uiautoagent/agent/executor.py
+++ b/src/uiautoagent/agent/executor.py
@@ -329,7 +329,7 @@ def execute_ai_task(
     system_prompt = get_system_prompt()
 
     for step in range(max_steps):
-        log.debug(f"AI决策中", step=step + 1, max_steps=max_steps)
+        log.debug("AI决策中", step=step + 1, max_steps=max_steps)
 
         # 准备数据
         screenshot_path = agent.get_current_screenshot()

--- a/src/uiautoagent/agent/report.py
+++ b/src/uiautoagent/agent/report.py
@@ -122,20 +122,20 @@ def _action_icon(action_type: str) -> str:
 
 def generate_html_report(
     steps: list[TaskStep],
-    task_dir: Path,
+    report_dir: Path,
     task: str | None = None,
 ) -> Path:
     """生成HTML可视化报告
 
     Args:
         steps: 任务步骤列表
-        task_dir: 任务目录
+        report_dir: 报告输出目录
         task: 任务描述
 
     Returns:
         报告文件路径
     """
-    annotated_dir = task_dir / "annotated"
+    annotated_dir = report_dir / "annotated"
     annotated_dir.mkdir(exist_ok=True)
 
     success_count = sum(1 for s in steps if s.success)
@@ -386,6 +386,6 @@ def generate_html_report(
 </body>
 </html>"""
 
-    report_path = task_dir / "report.html"
+    report_path = report_dir / "report.html"
     report_path.write_text(report_html, encoding="utf-8")
     return report_path

--- a/src/uiautoagent/ai.py
+++ b/src/uiautoagent/ai.py
@@ -12,12 +12,23 @@ from typing import Any
 
 import dictlog
 import httpx
-from openai import APIConnectionError, APITimeoutError, OpenAI, RateLimitError
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    InternalServerError,
+    OpenAI,
+    RateLimitError,
+)
 from openai.types.chat import ChatCompletion
 from pydantic import BaseModel, Field
 
 # 可重试的瞬态错误（换一个候选模型可能成功）
-_RETRYABLE_ERRORS = (APIConnectionError, APITimeoutError, RateLimitError)
+_RETRYABLE_ERRORS = (
+    APIConnectionError,
+    APITimeoutError,
+    RateLimitError,
+    InternalServerError,
+)
 
 # 模块级 logger
 log = dictlog.get_logger(__name__)

--- a/src/uiautoagent/ai.py
+++ b/src/uiautoagent/ai.py
@@ -12,9 +12,12 @@ from typing import Any
 
 import dictlog
 import httpx
-from openai import OpenAI
+from openai import APIConnectionError, APITimeoutError, OpenAI, RateLimitError
 from openai.types.chat import ChatCompletion
 from pydantic import BaseModel, Field
+
+# 可重试的瞬态错误（换一个候选模型可能成功）
+_RETRYABLE_ERRORS = (APIConnectionError, APITimeoutError, RateLimitError)
 
 # 模块级 logger
 log = dictlog.get_logger(__name__)
@@ -41,6 +44,13 @@ def _get_env(key: str, default: str | None = None) -> str | None:
     return os.getenv(f"UIAUTO_{key}", os.getenv(key, default))
 
 
+def _parse_model_list(value: str | None) -> list[str]:
+    """解析逗号分隔的模型配置。"""
+    if not value:
+        return []
+    return [model.strip() for model in value.split(",") if model.strip()]
+
+
 class Category(str, Enum):
     """AI 调用场景分类
 
@@ -53,11 +63,11 @@ class Category(str, Enum):
 
 
 # 不同场景的模型配置
-_MODEL_CONFIG: dict[Category, str] = {
-    Category.VISION: _get_env("MODEL_VISION") or "",
-    Category.TEXT: _get_env("MODEL_TEXT") or "",
+_MODEL_CONFIG: dict[Category, list[str]] = {
+    Category.VISION: _parse_model_list(_get_env("MODEL_VISION")),
+    Category.TEXT: _parse_model_list(_get_env("MODEL_TEXT")),
 }
-_DEFAULT_MODEL = _get_env("MODEL_NAME", "gpt-4o")
+_DEFAULT_MODELS = _parse_model_list(_get_env("MODEL_NAME")) or ["doubao-seed-2.0-pro"]
 
 
 class TokenStats(BaseModel):
@@ -205,37 +215,42 @@ def _get_ai_client() -> OpenAI:
     )
 
 
-def get_ai_model(category: Category | str | None = None) -> str:
+def _normalize_model_candidates(model: str | list[str] | None) -> list[str]:
+    """规范化候选模型列表。"""
+    if model is None:
+        return []
+    if isinstance(model, str):
+        return _parse_model_list(model)
+    return _parse_model_list(",".join(model))
+
+
+def get_ai_model(category: Category | str | None = None) -> list[str]:
     """
-    获取 AI 模型名称
+    获取 AI 候选模型列表
 
     Args:
         category: 可选的场景分类，用于获取特定场景的模型。
-                  如果为 None，返回默认模型。
+                  如果为 None，返回默认模型列表。
                   支持 Category 枚举值或对应的字符串值
 
     Returns:
-        模型名称，如 "gpt-4o"
+        模型名称列表，如 ["gpt-4o", "gpt-4o-mini"]
 
     Example:
         >>> from uiautoagent.ai import get_ai_model, Category
-        >>> get_ai_model()  # 获取默认模型
-        'gpt-4o'
-        >>> get_ai_model(Category.VISION)  # 获取视觉场景的模型
-        'gpt-4o-mini'
+        >>> get_ai_model()  # 获取默认模型列表
+        ['gpt-4o']
+        >>> get_ai_model(Category.VISION)  # 获取视觉场景的模型列表
+        ['gpt-4o-mini', 'gpt-4o']
         >>> get_ai_model("vision")  # 也支持字符串
-        'gpt-4o-mini'
+        ['gpt-4o-mini', 'gpt-4o']
     """
     if category:
-        # 如果是 Category 枚举，转换为字符串值
-        category_value = category.value if isinstance(category, Category) else category
-        # 查找对应的 Category 枚举
-        for cat in Category:
-            if cat.value == category_value and cat in _MODEL_CONFIG:
-                model = _MODEL_CONFIG[cat]
-                if model:
-                    return model
-    return _DEFAULT_MODEL or "gpt-4o"
+        cat = category if isinstance(category, Category) else Category(category)
+        models = _MODEL_CONFIG.get(cat)
+        if models:
+            return models.copy()
+    return _DEFAULT_MODELS.copy()
 
 
 def get_ai_config() -> dict:
@@ -248,8 +263,8 @@ def get_ai_config() -> dict:
     return {
         "base_url": _get_env("BASE_URL", "https://api.openai.com/v1")
         or "https://api.openai.com/v1",
-        "model": _DEFAULT_MODEL,
-        "timeout": int(_get_env("REQUEST_TIMEOUT", "30") or "30"),
+        "models": _DEFAULT_MODELS.copy(),
+        "timeout": int(_get_env("REQUEST_TIMEOUT", "60") or "60"),
     }
 
 
@@ -278,40 +293,53 @@ def check_model_available(model: str) -> bool:
 
 def check_all_models_available() -> bool:
     """
-    检查所有配置模型是否可用（默认模型 + 各 category 模型，去重）
+    检查所有已配置场景是否至少存在一个可用模型
 
     Returns:
-        True 表示全部可用，False 表示有模型不可用
+        True 表示所有场景都有可用模型，False 表示存在不可用场景
     """
-    # 收集所有唯一的模型名称
-    models: dict[str, list[str]] = {}  # model -> [label, ...]
-    default_model = _DEFAULT_MODEL or "gpt-4o"
-    models.setdefault(default_model, []).append("default")
-    for cat, m in _MODEL_CONFIG.items():
-        if m:
-            models.setdefault(m, []).append(cat.value)
+    model_groups: dict[str, list[str]] = {"default": _DEFAULT_MODELS.copy()}
+    for cat, models in _MODEL_CONFIG.items():
+        if models:
+            model_groups[cat.value] = models.copy()
 
-    log.info(f"检查模型可用性（共 {len(models)} 个）...", total=len(models))
+    checked: dict[str, bool] = {}
+    total_candidates = sum(len(models) for models in model_groups.values())
+    log.info(
+        f"检查模型可用性（共 {total_candidates} 个候选）...", total=total_candidates
+    )
+
     all_ok = True
-    for model, labels in models.items():
-        label = ", ".join(labels)
-        ok = check_model_available(model)
-        status = "✅" if ok else "❌"
-        log.info(
-            f"  {status} {model!r} [{label}]",
-            model=model,
-            label=label,
-            status=status,
-            available=ok,
-        )
-        if not ok:
+    for label, candidates in model_groups.items():
+        group_ok = False
+        for index, candidate in enumerate(candidates, start=1):
+            if candidate not in checked:
+                checked[candidate] = check_model_available(candidate)
+
+            ok = checked[candidate]
+            status = "✅" if ok else "❌"
+            log.info(
+                f"  {status} {candidate!r} [{label} #{index}]",
+                model=candidate,
+                label=label,
+                index=index,
+                status=status,
+                available=ok,
+            )
+            if ok:
+                group_ok = True
+                break
+
+        if not group_ok:
             all_ok = False
+            log.error("当前场景没有可用模型", label=label, candidates=candidates)
+
     return all_ok
 
 
 def chat_completion(
-    category: Category | str,
-    model: str | None = None,
+    category: Category,
+    model: str | list[str] | None = None,
     **kwargs: Any,
 ) -> ChatCompletion:
     """
@@ -322,10 +350,10 @@ def chat_completion(
 
     Args:
         category: 用途分类，用于 token 统计和模型选择。
-                  支持 Category 枚举值或对应的字符串值
-                  如果配置了对应的环境变量（如 MODEL_VISION），将使用该模型，
-                  否则使用默认模型（MODEL_NAME）。
-        model: 可选，显式指定模型。如果提供，将覆盖 category 的模型选择。
+                  如果配置了对应的环境变量（如 MODEL_VISION），将使用该场景的候选模型，
+                  否则使用默认模型列表（MODEL_NAME）。
+        model: 可选，显式指定模型。如果提供，将覆盖 category 的模型选择；
+               支持单个模型、逗号分隔字符串或模型列表。
         **kwargs: 传递给 chat.completions.create 的所有参数，包括：
             - messages: 消息列表
             - max_tokens: 最大生成 token 数
@@ -335,44 +363,36 @@ def chat_completion(
 
     Returns:
         ChatCompletion: API 响应对象
-
-    Example:
-        >>> from uiautoagent.ai import chat_completion, Category
-        >>> # 使用 Category 枚举（推荐）
-        >>> response = chat_completion(
-        ...     category=Category.VISION,
-        ...     messages=[{"role": "user", "content": "Hello"}],
-        ...     max_tokens=100,
-        ... )
-        >>> # 也支持字符串（向后兼容）
-        >>> response = chat_completion(
-        ...     category="plan",
-        ...     messages=[{"role": "user", "content": "Hello"}],
-        ...     max_tokens=100,
-        ... )
-        >>> # 显式指定模型
-        >>> response = chat_completion(
-        ...     category=Category.VISION,
-        ...     model="gpt-4o",
-        ...     messages=[{"role": "user", "content": "Hello"}],
-        ...     max_tokens=100,
-        ... )
-        >>> content = response.choices[0].message.content
     """
     client = _get_ai_client()
     tracker = TokenTracker(category)
+    model_candidates = (
+        get_ai_model(category) if model is None else _normalize_model_candidates(model)
+    )
+    if not model_candidates:
+        raise ValueError("未配置可用的模型")
 
-    # 如果没有显式指定模型，使用 category 对应的模型
-    if model is None:
-        model = get_ai_model(category)
-
-    # 注入 session_id（合并到 extra_body，不覆盖调用方已设置的值）
     extra_body = kwargs.pop("extra_body", {}) or {}
     extra_body.setdefault("session_id", SESSION_ID)
 
-    response = client.chat.completions.create(
-        model=model, extra_body=extra_body, **kwargs
-    )
-    tracker.record(response)
+    last_error: Exception | None = None
+    for index, candidate in enumerate(model_candidates, start=1):
+        try:
+            response = client.chat.completions.create(
+                model=candidate, extra_body=extra_body, **kwargs
+            )
+            tracker.record(response)
+            return response
+        except _RETRYABLE_ERRORS as e:
+            last_error = e
+            if index < len(model_candidates):
+                log.warning(
+                    "模型调用失败，尝试下一个候选模型",
+                    model=candidate,
+                    next_model=model_candidates[index],
+                    category=tracker.category,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
 
-    return response
+    raise last_error  # type: ignore[misc]

--- a/src/uiautoagent/cli/main.py
+++ b/src/uiautoagent/cli/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 import dictlog
 
@@ -13,16 +14,13 @@ from uiautoagent.ai import check_all_models_available
 from uiautoagent.controller import AndroidController, IOSController
 
 # 默认 logger，main 函数中会根据参数调整级别
-log = dictlog.get_logger()
+slog = dictlog.get_logger(__name__)
 
 
 def demo_manual_control(platform: str = "android", serial: str | None = None):
     """演示手动控制Agent执行任务（适用于已知步骤的任务）"""
-    pass
-
-    log.info("=" * 50)
+    log = slog.bind(platform=platform, serial=serial)
     log.info("📱 设备Agent - 手动控制模式")
-    log.info("=" * 50)
 
     # 检查设备
     if platform == "ios":
@@ -125,11 +123,8 @@ def demo_find_and_click(
     target: str = "返回按钮", platform: str = "android", serial: str | None = None
 ):
     """演示简单的查找并点击"""
-    pass
-
-    log.info("=" * 50)
+    log = slog.bind(target=target, platform=platform, serial=serial)
     log.info("📱 设备Agent - 查找并点击")
-    log.info("=" * 50)
 
     if platform == "ios":
         if serial:
@@ -189,6 +184,7 @@ def demo_find_and_click(
 
 def _run_extract(args: argparse.Namespace):
     """执行 extract 模式：从图片中提取内容"""
+    log = slog.bind(mode="extract", image=args.image, query=args.query)
     import json as _json
 
     from uiautoagent.detector.content_extractor import extract_content
@@ -286,8 +282,8 @@ def main():
     )
     args = parser.parse_args()
 
-    # 设置日志级别
-    log.level = getattr(dictlog, args.log_level)
+    log = slog.bind(mode=args.mode, task=args.task, platform=args.platform)
+    slog.level = getattr(dictlog, args.log_level)
 
     if not check_all_models_available():
         return
@@ -297,8 +293,6 @@ def main():
     if args.context:
         context = args.context.strip()
     elif args.context_file:
-        from pathlib import Path
-
         kpath = Path(args.context_file)
         if not kpath.exists():
             log.error("任务上下文文件不存在", file=str(kpath))

--- a/tests/e2e/test_extract_content_e2e.py
+++ b/tests/e2e/test_extract_content_e2e.py
@@ -1,0 +1,72 @@
+"""E2E integration tests for extract_content.
+
+Requires a real VISION model API (configured via .env).
+Run with: uv run pytest tests/e2e/test_extract_content_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from openai import InternalServerError, APIStatusError
+from PIL import Image, ImageDraw, ImageFont
+
+from uiautoagent.detector.content_extractor import ExtractionResult, extract_content
+
+_has_api_key = any(
+    os.getenv(k) for k in ("UIAUTO_API_KEY", "VISION_API_KEY", "OPENAI_API_KEY")
+)
+
+pytestmark = pytest.mark.skipif(
+    not _has_api_key,
+    reason="No API key configured — skipping e2e tests",
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_fixtures():
+    """Create fixture images if they don't exist."""
+    FIXTURES.mkdir(exist_ok=True)
+
+    price_path = FIXTURES / "simple_price_tag.png"
+    if not price_path.exists():
+        img = Image.new("RGB", (400, 300), "white")
+        draw = ImageDraw.Draw(img)
+        try:
+            font = ImageFont.truetype("/System/Library/Fonts/PingFang.ttc", 32)
+        except OSError:
+            font = ImageFont.load_default()
+        draw.text((30, 40), "苹果  ¥5.50", fill="black", font=font)
+        draw.text((30, 100), "香蕉  ¥3.20", fill="black", font=font)
+        draw.text((30, 160), "橙子  ¥4.80", fill="black", font=font)
+        draw.rectangle([20, 25, 380, 220], outline="gray", width=2)
+        img.save(price_path)
+
+
+def test_extract_content_e2e():
+    """E2E: 生成图片 → 调用真实 API → 验证结构化提取结果"""
+    img = FIXTURES / "simple_price_tag.png"
+
+    try:
+        result = extract_content(img, "提取所有商品名称和价格")
+    except (InternalServerError, APIStatusError) as e:
+        pytest.xfail(f"Transient API error: {e}")
+
+    assert isinstance(result, ExtractionResult)
+    assert result.success is True
+    assert result.content is not None
+    assert result.thought is not None
+    assert result.raw_response is not None
+
+    content_str = json.dumps(result.content, ensure_ascii=False)
+    print(
+        f"\n[extract_content result]\nthought: {result.thought}\ncontent: {content_str}\n"
+    )
+    # AI 应该识别出图片中的文字内容
+    assert result.thought is not None
+    assert len(content_str) > 5

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,156 @@
+"""Tests for AI model selection and fallback."""
+
+from importlib import import_module, reload
+from unittest.mock import MagicMock
+
+import pytest
+from openai import APIConnectionError, RateLimitError
+
+
+@pytest.fixture
+def ai_module(monkeypatch):
+    monkeypatch.delenv("UIAUTO_MODEL_NAME", raising=False)
+    monkeypatch.delenv("MODEL_NAME", raising=False)
+    monkeypatch.delenv("UIAUTO_MODEL_VISION", raising=False)
+    monkeypatch.delenv("MODEL_VISION", raising=False)
+    monkeypatch.delenv("UIAUTO_MODEL_TEXT", raising=False)
+    monkeypatch.delenv("MODEL_TEXT", raising=False)
+
+    module = import_module("uiautoagent.ai")
+    module._get_ai_client.cache_clear()
+    return reload(module)
+
+
+def _make_chat_response(content: str = "ok") -> MagicMock:
+    msg = MagicMock()
+    msg.content = content
+    choice = MagicMock()
+    choice.message = msg
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    return resp
+
+
+def test_get_ai_model_returns_category_candidates(monkeypatch, ai_module):
+    monkeypatch.setenv("UIAUTO_MODEL_NAME", "default-a,default-b")
+    monkeypatch.setenv("UIAUTO_MODEL_VISION", "vision-a, vision-b")
+
+    module = reload(ai_module)
+
+    assert module.get_ai_model(module.Category.VISION) == ["vision-a", "vision-b"]
+
+
+def test_get_ai_model_falls_back_to_default_candidates(monkeypatch, ai_module):
+    monkeypatch.setenv("UIAUTO_MODEL_NAME", "default-a, default-b")
+
+    module = reload(ai_module)
+
+    assert module.get_ai_model(module.Category.TEXT) == ["default-a", "default-b"]
+    assert module.get_ai_model() == ["default-a", "default-b"]
+
+
+def test_chat_completion_falls_back_to_next_model(ai_module, monkeypatch):
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        APIConnectionError(request=None),
+        _make_chat_response("done"),
+    ]
+    monkeypatch.setattr(ai_module, "_get_ai_client", lambda: client)
+    monkeypatch.setattr(ai_module, "get_ai_model", lambda *_: ["model-a", "model-b"])
+
+    response = ai_module.chat_completion(
+        category=ai_module.Category.TEXT,
+        messages=[{"role": "user", "content": "hello"}],
+    )
+
+    assert response.choices[0].message.content == "done"
+    assert client.chat.completions.create.call_count == 2
+    first_call = client.chat.completions.create.call_args_list[0].kwargs
+    second_call = client.chat.completions.create.call_args_list[1].kwargs
+    assert first_call["model"] == "model-a"
+    assert second_call["model"] == "model-b"
+
+
+def test_chat_completion_raises_last_error_when_all_models_fail(ai_module, monkeypatch):
+    client = MagicMock()
+    last_error = RateLimitError(
+        message="rate limited",
+        response=MagicMock(status_code=429),
+        body=None,
+    )
+    client.chat.completions.create.side_effect = [
+        APIConnectionError(request=None),
+        last_error,
+    ]
+    monkeypatch.setattr(ai_module, "_get_ai_client", lambda: client)
+    monkeypatch.setattr(ai_module, "get_ai_model", lambda *_: ["model-a", "model-b"])
+
+    with pytest.raises(RateLimitError):
+        ai_module.chat_completion(
+            category=ai_module.Category.TEXT,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+
+def test_chat_completion_uses_explicit_model_candidates(ai_module, monkeypatch):
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        APIConnectionError(request=None),
+        _make_chat_response("done"),
+    ]
+    monkeypatch.setattr(ai_module, "_get_ai_client", lambda: client)
+
+    response = ai_module.chat_completion(
+        category=ai_module.Category.TEXT,
+        model="manual-a, manual-b",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+
+    assert response.choices[0].message.content == "done"
+    assert (
+        client.chat.completions.create.call_args_list[0].kwargs["model"] == "manual-a"
+    )
+    assert (
+        client.chat.completions.create.call_args_list[1].kwargs["model"] == "manual-b"
+    )
+
+
+def test_chat_completion_does_not_retry_on_non_retryable_error(ai_module, monkeypatch):
+    client = MagicMock()
+    client.chat.completions.create.side_effect = ValueError("bad request")
+    monkeypatch.setattr(ai_module, "_get_ai_client", lambda: client)
+    monkeypatch.setattr(ai_module, "get_ai_model", lambda *_: ["model-a", "model-b"])
+
+    with pytest.raises(ValueError, match="bad request"):
+        ai_module.chat_completion(
+            category=ai_module.Category.TEXT,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+    assert client.chat.completions.create.call_count == 1
+
+
+def test_check_all_models_available_accepts_one_candidate_per_group(
+    ai_module, monkeypatch
+):
+    monkeypatch.setenv("UIAUTO_MODEL_NAME", "default-a,default-b")
+    monkeypatch.setenv("UIAUTO_MODEL_VISION", "vision-a,vision-b")
+    monkeypatch.setenv("UIAUTO_MODEL_TEXT", "text-a")
+    module = reload(ai_module)
+
+    checked_models: list[str] = []
+
+    def fake_check(model: str) -> bool:
+        checked_models.append(model)
+        return model in {"default-b", "vision-b", "text-a"}
+
+    monkeypatch.setattr(module, "check_model_available", fake_check)
+
+    assert module.check_all_models_available() is True
+    assert checked_models == [
+        "default-a",
+        "default-b",
+        "vision-a",
+        "vision-b",
+        "text-a",
+    ]

--- a/tests/test_device_agent_actions.py
+++ b/tests/test_device_agent_actions.py
@@ -71,7 +71,7 @@ def test_long_press_by_bbox(tmp_path):
     agent = DeviceAgent(
         controller,
         config=AgentConfig(
-            tasks_dir=str(tmp_path), save_screenshots=False, verbose=False
+            report_dir=str(tmp_path), save_screenshots=False, verbose=False
         ),
     )
 
@@ -102,7 +102,7 @@ def test_app_reboot_action(tmp_path):
     agent = DeviceAgent(
         controller,
         config=AgentConfig(
-            tasks_dir=str(tmp_path), save_screenshots=False, verbose=False
+            report_dir=str(tmp_path), save_screenshots=False, verbose=False
         ),
     )
 


### PR DESCRIPTION
- 模型配置支持逗号分隔多个候选模型，按顺序尝试回退
- chat_completion 遇到瞬态错误自动切换下一个候选模型
- check_all_models_available 检查每个场景至少有一个可用模型
- CLI 日志改用 slog.bind() 绑定上下文参数
- 移除 executor.py 中不必要的 f-string
- 新增 test_ai.py 测试用例
- 更新 README 文档说明候选模型和回退功能